### PR TITLE
Page after registered and first login page

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -72,6 +72,7 @@ class User < ActiveRecord::Base
   end
 
   before_validation :clean_document_number
+  before_create :verified_by_default
 
   # Get the existing user by email if the provider gives us a verified email.
   def self.first_or_initialize_for_oauth(auth)
@@ -340,6 +341,10 @@ class User < ActiveRecord::Base
         attributes: :username,
         maximum: User.username_max_length)
       validator.validate(self)
+    end
+
+    def verified_by_default
+      self.verified_at = Date.current
     end
 
 end

--- a/app/views/account/show.html.erb
+++ b/app/views/account/show.html.erb
@@ -121,48 +121,56 @@
           <p><%= t("account.show.user_permission_info") %></p>
 
           <ul>
-            <li><span class="icon-check"></span>&nbsp;<%= t("account.show.user_permission_debates") %></li>
+            <li><span class="icon-check"></span>&nbsp;<%= t("welcome.welcome.user_permission_proposal_participate") %></li>
             <li><span class="icon-check"></span>&nbsp;<%= t("account.show.user_permission_proposal") %></li>
-            <li>
-              <% if current_user.level_two_or_three_verified? %>
-                <span class="icon-check"></span>
-              <% else %>
-                <span class="icon-x"></span>
-              <% end %>
-              <%= t("account.show.user_permission_support_proposal") %>
-            </li>
-            <li>
-              <% if current_user.level_three_verified? %>
-                <span class="icon-check"></span>
-              <% else %>
-                <span class="icon-x"></span>
-              <% end %>
-              <%= t("account.show.user_permission_votes") %>
-            </li>
+            <% if setting['org_name'] != "MASDEMOCRACIAEUROPA" %>
+
+              <li>
+                <% if current_user.level_two_or_three_verified? %>
+                  <span class="icon-check"></span>
+                <% else %>
+                  <span class="icon-x"></span>
+                <% end %>
+                <%= t("account.show.user_permission_support_proposal") %>
+              </li>
+              <li>
+                <% if current_user.level_three_verified? %>
+                  <span class="icon-check"></span>
+                <% else %>
+                  <span class="icon-x"></span>
+                <% end %>
+                <%= t("account.show.user_permission_votes") %>
+              </li>
+
+            <% end %>
           </ul>
 
-          <p>
-            <span><%= t("account.show.user_permission_verify_info") %></span>
-          </p>
-          <p>
-            <%= t("account.show.user_permission_verify") %>
-          </p>
+          <% if setting['org_name'] != "MASDEMOCRACIAEUROPA" %>
 
-          <% unless @account.organization? %>
-            <div>
-              <span class="verify-account">
-                <% if current_user.level_three_verified? %>
-                  <p class="already-verified">
-                    <span class="icon-check"></span>
-                    <%= t("account.show.verified_account") %>
-                  </p>
-                <% elsif current_user.level_two_verified? %>
-                  <%= link_to t("account.show.finish_verification"), verification_path, class: "button success" %>
-                <% else %>
-                  <%= link_to t("account.show.verify_my_account"), verification_path, class: "button success" %>
-                <% end %>
-              </span>
-            </div>
+            <p>
+              <span><%= t("account.show.user_permission_verify_info") %></span>
+            </p>
+            <p>
+              <%= t("account.show.user_permission_verify") %>
+            </p>
+
+            <% unless @account.organization? %>
+              <div>
+                <span class="verify-account">
+                  <% if current_user.level_three_verified? %>
+                    <p class="already-verified">
+                      <span class="icon-check"></span>
+                      <%= t("account.show.verified_account") %>
+                    </p>
+                  <% elsif current_user.level_two_verified? %>
+                    <%= link_to t("account.show.finish_verification"), verification_path, class: "button success" %>
+                  <% else %>
+                    <%= link_to t("account.show.verify_my_account"), verification_path, class: "button success" %>
+                  <% end %>
+                </span>
+              </div>
+            <% end %>
+
           <% end %>
         </div>
       </div>

--- a/app/views/custom/account/show.html.erb
+++ b/app/views/custom/account/show.html.erb
@@ -121,47 +121,56 @@
           <p><%= t("account.show.user_permission_info") %></p>
 
           <ul>
-            <li><span class="icon-check"></span>&nbsp;<%= t("account.show.user_permission_debates") %></li>
+            <li><span class="icon-check"></span>&nbsp;<%= t("welcome.welcome.user_permission_proposal_participate") %></li>
             <li><span class="icon-check"></span>&nbsp;<%= t("account.show.user_permission_proposal") %></li>
-            <li>
-              <% if current_user.level_two_or_three_verified? %>
-                <span class="icon-check"></span>
-              <% else %>
-                <span class="icon-x"></span>
-              <% end %>
-              <%= t("account.show.user_permission_support_proposal") %>
-            </li>
-            <li>
-              <% if current_user.level_three_verified? %>
-                <span class="icon-check"></span>
-              <% else %>
-                <span class="icon-x"></span>
-              <% end %>
-              <%= t("account.show.user_permission_votes") %>
-            </li>
-          </ul>
-          <p>
-            <span><%= t("account.show.user_permission_verify_info") %></span>
-          </p>
-          <p>
-            <%= t("account.show.user_permission_verify") %>
-          </p>
+            <% if setting['org_name'] != "MASDEMOCRACIAEUROPA" %>
 
-          <% unless @account.organization? %>
-            <div>
-              <span class="verify-account">
-                <% if current_user.level_three_verified? %>
-                  <p class="already-verified">
-                    <span class="icon-check"></span>
-                    <%= t("account.show.verified_account") %>
-                  </p>
-                <% elsif current_user.level_two_verified? %>
-                  <%= link_to t("account.show.finish_verification"), verification_path, class: "button success" %>
+              <li>
+                <% if current_user.level_two_or_three_verified? %>
+                  <span class="icon-check"></span>
                 <% else %>
-                  <%= link_to t("account.show.verify_my_account"), verification_path, class: "button success" %>
+                  <span class="icon-x"></span>
                 <% end %>
-              </span>
-            </div>
+                <%= t("account.show.user_permission_support_proposal") %>
+              </li>
+              <li>
+                <% if current_user.level_three_verified? %>
+                  <span class="icon-check"></span>
+                <% else %>
+                  <span class="icon-x"></span>
+                <% end %>
+                <%= t("account.show.user_permission_votes") %>
+              </li>
+
+            <% end %>
+          </ul>
+
+          <% if setting['org_name'] != "MASDEMOCRACIAEUROPA" %>
+
+            <p>
+              <span><%= t("account.show.user_permission_verify_info") %></span>
+            </p>
+            <p>
+              <%= t("account.show.user_permission_verify") %>
+            </p>
+
+            <% unless @account.organization? %>
+              <div>
+                <span class="verify-account">
+                  <% if current_user.level_three_verified? %>
+                    <p class="already-verified">
+                      <span class="icon-check"></span>
+                      <%= t("account.show.verified_account") %>
+                    </p>
+                  <% elsif current_user.level_two_verified? %>
+                    <%= link_to t("account.show.finish_verification"), verification_path, class: "button success" %>
+                  <% else %>
+                    <%= link_to t("account.show.verify_my_account"), verification_path, class: "button success" %>
+                  <% end %>
+                </span>
+              </div>
+            <% end %>
+
           <% end %>
         </div>
       </div>

--- a/config/locales/custom/en/general.yml
+++ b/config/locales/custom/en/general.yml
@@ -1,0 +1,4 @@
+en:
+  account:
+    show:
+      email_on_comment_label: Notify me by email when someone comments on my proposals

--- a/config/locales/custom/es/general.yml
+++ b/config/locales/custom/es/general.yml
@@ -1,0 +1,4 @@
+es:
+  account:
+    show:
+      email_on_comment_label: Recibir un email cuando alguien comenta en mis propuestas

--- a/config/locales/custom/fr/general.yml
+++ b/config/locales/custom/fr/general.yml
@@ -1,0 +1,4 @@
+fr:
+  account:
+    show:
+      email_on_comment_label: Me notifier par email quand quelqu'un commente mes propositions

--- a/config/locales/custom/nl/general.yml
+++ b/config/locales/custom/nl/general.yml
@@ -1,0 +1,4 @@
+nl:
+  account:
+    show:
+      email_on_comment_label: Stuur me een email als iemand op mijn voorstellen reageert

--- a/config/locales/custom/pt-BR/general.yml
+++ b/config/locales/custom/pt-BR/general.yml
@@ -1,0 +1,5 @@
+pt-BR:
+  account:
+    show:
+      email_on_comment_label: Notificar-me por email quando alguém comentar sobre
+        minhas propostas

--- a/config/locales/custom/val/general.yml
+++ b/config/locales/custom/val/general.yml
@@ -1,0 +1,4 @@
+val:
+  account:
+    show:
+      email_on_comment_label: Rebre un correu electrònic quan algú comenta en les meues propostes

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -2,7 +2,7 @@ en:
   account:
     show:
       change_credentials_link: Change my credentials
-      email_on_comment_label: Notify me by email when someone comments on my proposals
+      email_on_comment_label: Notify me by email when someone comments on my proposals or debates
       email_on_comment_reply_label: Notify me by email when someone replies to my comments
       erase_account_link: Erase my account
       finish_verification: Complete verification

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -2,7 +2,7 @@ en:
   account:
     show:
       change_credentials_link: Change my credentials
-      email_on_comment_label: Notify me by email when someone comments on my proposals or debates
+      email_on_comment_label: Notify me by email when someone comments on my proposals
       email_on_comment_reply_label: Notify me by email when someone replies to my comments
       erase_account_link: Erase my account
       finish_verification: Complete verification
@@ -820,6 +820,7 @@ en:
       user_permission_debates: Participate on debates
       user_permission_info: With your account you can...
       user_permission_proposal: Create new proposals
+      user_permission_proposal_participate: Participate on proposals
       user_permission_support_proposal: Support proposals*
       user_permission_verify: To perform all the actions verify your account.
       user_permission_verify_info: "* Only for users on Census."

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -2,7 +2,7 @@ es:
   account:
     show:
       change_credentials_link: Cambiar mis datos de acceso
-      email_on_comment_label: Recibir un email cuando alguien comenta en mis propuestas o debates
+      email_on_comment_label: Recibir un email cuando alguien comenta en mis propuestas
       email_on_comment_reply_label: Recibir un email cuando alguien contesta a mis comentarios
       erase_account_link: Darme de baja
       finish_verification: Finalizar verificación
@@ -819,6 +819,7 @@ es:
       user_permission_debates: Participar en debates
       user_permission_info: Con tu cuenta ya puedes...
       user_permission_proposal: Crear nuevas propuestas
+      user_permission_proposal_participate: Participar en propuestas
       user_permission_support_proposal: Apoyar propuestas*
       user_permission_verify: Para poder realizar todas las acciones, verifica tu cuenta.
       user_permission_verify_info: "* Sólo usuarios empadronados."

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -2,7 +2,7 @@ es:
   account:
     show:
       change_credentials_link: Cambiar mis datos de acceso
-      email_on_comment_label: Recibir un email cuando alguien comenta en mis propuestas
+      email_on_comment_label: Recibir un email cuando alguien comenta en mis propuestas o debates
       email_on_comment_reply_label: Recibir un email cuando alguien contesta a mis comentarios
       erase_account_link: Darme de baja
       finish_verification: Finalizar verificación

--- a/config/locales/fr/general.yml
+++ b/config/locales/fr/general.yml
@@ -4,7 +4,6 @@ fr:
     show:
       change_credentials_link: Changer mes autorisations
       email_on_comment_label: Me notifier par email quand quelqu'un commente mes propositions
-        ou mes débats
       email_on_comment_reply_label: Me notifier par email quand quelqu'un répond à
         mes commentaires
       erase_account_link: Supprimer mon compte
@@ -1637,6 +1636,7 @@ fr:
       user_permission_debates: Participez aux débats !
       user_permission_info: Avec votre compte, vous pouvez...
       user_permission_proposal: Créer des propositions
+      user_permission_proposal_participate: Participez aux propositions
       user_permission_support_proposal: Soutenir des propositions
       user_permission_verify: Réaliser toutes ces actions %{verify}.
       user_permission_verify_info: "* Uniquement pour les utilisateurs inscrits sur

--- a/config/locales/fr/general.yml
+++ b/config/locales/fr/general.yml
@@ -3,7 +3,7 @@ fr:
   account:
     show:
       change_credentials_link: Changer mes autorisations
-      email_on_comment_label: Me notifier par email quand quelqu'un commente mes propositions
+      email_on_comment_label: Me notifier par email quand quelqu'un commente mes propositions ou mes débats
       email_on_comment_reply_label: Me notifier par email quand quelqu'un répond à
         mes commentaires
       erase_account_link: Supprimer mon compte

--- a/config/locales/he/general.yml
+++ b/config/locales/he/general.yml
@@ -569,6 +569,7 @@ he:
       user_permission_debates: להשתתף בדיונים
       user_permission_info: עם החשבון שלך אפשר ...
       user_permission_proposal: ליצור הצעות חדשות
+      user_permission_proposal_participate: השתתף בהצעות
       user_permission_support_proposal: הצעות תמיכה*
       user_permission_verify: כדי לבצע את כל הפעולות, עליך לאמת את חשבונך
       user_permission_verify_info: "* רק עבור משתמשים/ות במפקד אוכלוסין."

--- a/config/locales/it/general.yml
+++ b/config/locales/it/general.yml
@@ -746,6 +746,7 @@ it:
       user_permission_debates: ""
       user_permission_info: ""
       user_permission_proposal: ""
+      user_permission_proposal_participate: ""
       user_permission_support_proposal: ""
       user_permission_verify: ""
       user_permission_verify_info: ""

--- a/config/locales/nl/general.yml
+++ b/config/locales/nl/general.yml
@@ -3,7 +3,7 @@ nl:
   account:
     show:
       change_credentials_link: Pas mijn toegangsgegevens aan
-      email_on_comment_label: Stuur me een email als iemand op mijn voorstellen reageert
+      email_on_comment_label: Stuur me een email als iemand op mijn voorstellen of discussie reageert
       email_on_comment_reply_label: Stuur me een email wanneer iemand op mijn voorstellen reageert
       erase_account_link: Verwijder mijn account
       finish_verification: Maak verificatieproces af

--- a/config/locales/nl/general.yml
+++ b/config/locales/nl/general.yml
@@ -3,7 +3,7 @@ nl:
   account:
     show:
       change_credentials_link: Pas mijn toegangsgegevens aan
-      email_on_comment_label: Stuur me een email als iemand op mijn voorstellen of discussie reageert
+      email_on_comment_label: Stuur me een email als iemand op mijn voorstellen reageert
       email_on_comment_reply_label: Stuur me een email wanneer iemand op mijn voorstellen reageert
       erase_account_link: Verwijder mijn account
       finish_verification: Maak verificatieproces af
@@ -692,6 +692,7 @@ nl:
       user_permission_debates: Deelnemen aan discussies
       user_permission_info: Met uw account kunt u..
       user_permission_proposal: Doe nieuwe voorstellen
+      user_permission_proposal_participate: Neem deel aan voorstellen
       user_permission_support_proposal: Steun voorstellen*
       user_permission_verify: Verifieer uw account om alles te kunnen.
       user_permission_verify_info: "* allen voor deelnemers uit de regio."
@@ -707,4 +708,3 @@ nl:
   invisible_captcha:
     sentence_for_humans: "Negeer dit veld als u mens bent"
     timestamp_error_message: "Sorry, dat ging te snel! Probeer nog eens."
-

--- a/config/locales/pt-BR/general.yml
+++ b/config/locales/pt-BR/general.yml
@@ -7,7 +7,7 @@ pt-BR:
     show:
       change_credentials_link: Alterar meus dados pessoais
       email_on_comment_label: Notificar-me por email quando alguém comentar sobre
-        minhas propostas
+        minhas propostas ou debates
       email_on_comment_reply_label: Notificar-me por email quando alguém responder
         sobre meus comentários
       erase_account_link: Apagar minha conta

--- a/config/locales/pt-BR/general.yml
+++ b/config/locales/pt-BR/general.yml
@@ -7,7 +7,7 @@ pt-BR:
     show:
       change_credentials_link: Alterar meus dados pessoais
       email_on_comment_label: Notificar-me por email quando alguém comentar sobre
-        minhas propostas ou debates
+        minhas propostas
       email_on_comment_reply_label: Notificar-me por email quando alguém responder
         sobre meus comentários
       erase_account_link: Apagar minha conta
@@ -1648,6 +1648,7 @@ pt-BR:
       user_permission_debates: Participar nos debates
       user_permission_info: Com a sua conta você pode...
       user_permission_proposal: Criar novas propostas
+      user_permission_proposal_participate: Participar nos propostas
       user_permission_support_proposal: Apoiar propostas*
       user_permission_verify: Para executar todas as ações %{verify}
       user_permission_verify_info: "* Somente usuários no Censo de Madrid"

--- a/config/locales/val/general.yml
+++ b/config/locales/val/general.yml
@@ -2,7 +2,7 @@ val:
   account:
     show:
       change_credentials_link: Canviar les meues dades d'acces
-      email_on_comment_label: Rebre un correu electrònic quan algú comenta en les meues propostes
+      email_on_comment_label: Rebre un correu electrònic quan algú comenta en les meues propostes o debats
       email_on_comment_reply_label: Rebre un correu electrònic quant algú contesta els meus comentaris
       erase_account_link: Eliminar el meu compte
       finish_verification: Finalitzar verificació

--- a/config/locales/val/general.yml
+++ b/config/locales/val/general.yml
@@ -2,7 +2,7 @@ val:
   account:
     show:
       change_credentials_link: Canviar les meues dades d'acces
-      email_on_comment_label: Rebre un correu electrònic quan algú comenta en les meues propostes o debats
+      email_on_comment_label: Rebre un correu electrònic quan algú comenta en les meues propostes
       email_on_comment_reply_label: Rebre un correu electrònic quant algú contesta els meus comentaris
       erase_account_link: Eliminar el meu compte
       finish_verification: Finalitzar verificació
@@ -786,6 +786,7 @@ val:
       user_permission_debates: Participar en debats
       user_permission_info: Amb el teu compte ja pots...
       user_permission_proposal: Crear noves propostes
+      user_permission_proposal_participate: Participar en propostes
       user_permission_support_proposal: Avalar propostes*
       user_permission_verify: Per a poder realitzar totes les accions verifica el teu compte.
       user_permission_verify_info: "* Sols usuaris empadronats."


### PR DESCRIPTION
References
==========
> #4 

Objectives
==========
> Remove page after registered. This page displayed verification info.
> Verify all uses before create
> Remove all info on account page that is not reference to proposals

Visual Changes
=======================
![Visual changes account page](https://user-images.githubusercontent.com/16189/40234637-e3d92374-5aa7-11e8-8d11-9b267c556c27.png)
