### PR TITLE
Override front end top_links partial

### DIFF
--- a/app/views/custom/shared/_top_links.html.erb
+++ b/app/views/custom/shared/_top_links.html.erb
@@ -1,0 +1,13 @@
+<ul class="no-bullet external-links">
+  <% if setting['blog_url'] %>
+    <li>
+      <%= link_to t("layouts.header.external_link_blog"),
+                  setting['blog_url'],
+                  target: "_blank",
+                  rel: "nofollow",
+                  title: t("shared.go_to_page") + t("layouts.header.external_link_blog") + t('shared.target_blank_html') %>
+    </li>
+  <% end %>
+
+  <%= raw content_block("top_links", I18n.locale) %>
+</ul>


### PR DESCRIPTION
References
==========
#9

Objectives
==========
Hide unuseful top bar links.

Visual Changes (if any)
=======================
**Before**
![captura de pantalla 2018-05-21 a las 11 48 55](https://user-images.githubusercontent.com/15726/40301650-02578f6a-5ced-11e8-8960-8de89b5346d3.png)

**After**
![captura de pantalla 2018-05-21 a las 11 49 10](https://user-images.githubusercontent.com/15726/40301649-0225e3b6-5ced-11e8-9ee3-1934447e4d81.png)

Notes
=====================
> Mention rake tasks or actions to be done when deploying this changes to a server (if any).
> Explain any caveats, or important things to notice like deprecations (if any).
