### PR TITLE
[WIP] Use author username instead of document_number on responsible_name field

### DIFF
--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -41,7 +41,7 @@ class Proposal < ActiveRecord::Base
   validates :title, length: { in: 4..Proposal.title_max_length }
   validates :description, length: { maximum: Proposal.description_max_length }
   validates :question, length: { in: 10..Proposal.question_max_length }
-  validates :responsible_name, length: { in: 6..Proposal.responsible_name_max_length }
+  validates :responsible_name, length: { in: 6..Proposal.responsible_name_max_length } unless Setting["feature.user.skip_verification"] == "true"
   validates :retired_reason, inclusion: { in: RETIRE_OPTIONS, allow_nil: true }
 
   validates :terms_of_service, acceptance: { allow_nil: false }, on: :create
@@ -219,7 +219,11 @@ class Proposal < ActiveRecord::Base
 
     def set_responsible_name
       if author
-        self.responsible_name = author.username
+        if author.document_number.present?
+          self.responsible_name = author.document_number
+        elsif Setting["feature.user.skip_verification"] == "true"
+          self.responsible_name = author.username
+        end
       end
     end
 

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -218,8 +218,8 @@ class Proposal < ActiveRecord::Base
   protected
 
     def set_responsible_name
-      if author && author.document_number?
-        self.responsible_name = author.document_number
+      if author
+        self.responsible_name = author.username
       end
     end
 

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -48,7 +48,7 @@ class Proposal < ActiveRecord::Base
 
   validate :valid_video_url?
 
-  before_validation :set_responsible_name
+  before_validation :set_responsible_name unless Setting["feature.user.skip_verification"] == "true"
 
   before_save :calculate_hot_score, :calculate_confidence_score
 
@@ -218,12 +218,8 @@ class Proposal < ActiveRecord::Base
   protected
 
     def set_responsible_name
-      if author
-        if author.document_number.present?
-          self.responsible_name = author.document_number
-        elsif Setting["feature.user.skip_verification"] == "true"
-          self.responsible_name = author.username
-        end
+      if author && author.document_number?
+        self.responsible_name = author.document_number
       end
     end
 

--- a/spec/models/custom/proposal_spec.rb
+++ b/spec/models/custom/proposal_spec.rb
@@ -1,0 +1,20 @@
+# coding: utf-8
+require 'rails_helper'
+
+describe Proposal do
+  let(:user) { create(:user, document_number: nil) }
+  let(:proposal) { build(:proposal, author: user, responsible_name: nil) }
+
+  before do
+    Setting["feature.user.skip_verification"] = 'true'
+  end
+
+  after do
+    Setting["feature.user.skip_verification"] = 'false'
+  end
+
+  it "is valid with user without verification" do
+    expect(proposal).to be_valid
+  end
+
+end


### PR DESCRIPTION
Objectives
==========
Allow (unverified) users to create proposals. All users are unverified in this application so it's not posible to populate proposal.responsible_name with author document_number because it will never exist.

We have to use another data that would be present for sure like username or email.

Another option is to use verification setting created in #36 

Visual Changes (if any)
=======================
> Any visual changes? please attach screenshots (or gifs) showing them.
> If modified views are public (not the admin panel), try them in mobile display (with your browser's developer console) and add screenshots.

Notes
=====================
> Mention rake tasks or actions to be done when deploying this changes to a server (if any).
> Explain any caveats, or important things to notice like deprecations (if any).
