### PR TITLE
Create 'changes suggest' and 'complementary proposal' buttons.

### DIFF
--- a/app/assets/javascripts/custom.js
+++ b/app/assets/javascripts/custom.js
@@ -1,7 +1,19 @@
 // Overrides and adds customized javascripts in this file
-// Read more on documentation: 
+// Read more on documentation:
 // * English: https://github.com/consul/consul/blob/master/CUSTOMIZE_EN.md#javascript
 // * Spanish: https://github.com/consul/consul/blob/master/CUSTOMIZE_ES.md#javascript
 //
 //
 
+function initCustomModules(){
+  $('#js-proposal-change-suggest').click(function(){
+    $('#js-suggest-notice').removeClass('hide');
+  });
+}
+
+$(function(){
+
+  $(document).ready(initCustomModules);
+  $(document).on('page:load', initCustomModules);
+  $(document).on('ajax:complete', initCustomModules);
+});

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -21,6 +21,11 @@ class ProposalsController < ApplicationController
   helper_method :resource_model, :resource_name
   respond_to :html, :js
 
+  def new
+    super
+    @original_proposal = Proposal.find(params[:original_proposal_id]) if params[:original_proposal_id].present?
+  end
+
   def show
     super
     @notifications = @proposal.notifications

--- a/app/views/custom/proposals/new.html.erb
+++ b/app/views/custom/proposals/new.html.erb
@@ -3,12 +3,21 @@
   <div class="small-12 medium-9 column">
     <%= back_link_to %>
 
-    <h1><%= t("proposals.new.start_new") %></h1>
+    <% if @original_proposal.present? %>
+      <h1><%= t("proposals.new.start_complementary") %></h1>
+    <% else %>
+      <h1><%= t("proposals.new.start_new") %></h1>
+    <% end %>
     <div data-alert class="callout primary">
       <%= link_to help_path(anchor: "proposals"), title: t('shared.target_blank_html'), target: "_blank" do %>
         <%= t("proposals.new.more_info")%>
       <% end %>
     </div>
+    <% if @original_proposal.present? %>
+      <div data-alert class="callout warning">
+        <%= t "proposals.new.suggest_warning_html", title: @original_proposal.title, link: proposal_path(@original_proposal) %>
+      </div>
+    <% end %>
     <%= render "proposals/form", form_url: proposals_url %>
   </div>
 

--- a/app/views/custom/proposals/show.html.erb
+++ b/app/views/custom/proposals/show.html.erb
@@ -146,6 +146,20 @@
       </div>
 
       <aside class="small-12 medium-3 column">
+
+        <% if !author_of_proposal?(@proposal) || current_user.blank? %>
+          <div class="sidebar-divider"></div>
+          <p class="sidebar-title"><%= t("proposals.show.act") %></p>
+          <div class="show-actions-menu">
+            <%= link_to new_proposal_path(original_proposal_id: @proposal.id), class: 'button hollow expanded' do %>
+                        <%= t("proposals.show.complementary_link") %>
+            <% end %>
+            <%= link_to '#js-suggest-notice', class: 'button hollow expanded', id: 'js-proposal-change-suggest' do %>
+                        <%= t("proposals.show.suggest_link") %>
+            <% end %>
+          </div>
+        <% end %>
+
         <% if author_of_proposal?(@proposal) || current_editable?(@proposal) || can_destroy_image?(@proposal) %>
           <div class="sidebar-divider"></div>
           <h2><%= t("proposals.show.author") %></h2>
@@ -243,6 +257,11 @@
 
 <div class="tabs-content" data-tabs-content="proposals_tabs" role="tablist">
   <div class="tabs-panel is-active" id="tab-comments" role="tab">
+    <%= render 'shared/notice',
+                id: 'js-suggest-notice',
+                type: 'notice',
+                klass: 'hide column',
+                text: t('proposals.show.suggest_text') %>
     <%= render "proposals/comments" %>
   </div>
 

--- a/app/views/custom/shared/_notice.html.erb
+++ b/app/views/custom/shared/_notice.html.erb
@@ -1,0 +1,11 @@
+<div id="<%= id %>" data-alert class="<%= klass %>" data-closable>
+  <div class="callout notice <%= type %>">
+    <button class="close-button" aria-label="<%= t("application.close") %>" type="button" data-close>
+      <span aria-hidden="true">&times;</span>
+    </button>
+    <div class="notice-text">
+      <%= text %>
+    </div>
+  </div>
+  <br>
+</div>

--- a/config/locales/custom/en/general.yml
+++ b/config/locales/custom/en/general.yml
@@ -37,14 +37,22 @@ en:
       tags_label: Keywords
       tags_placeholder: "Enter the keywords you would like to use, separated by commas (',')"
     new:
+      recommendations_title: Before you start writing your proposal...
       recommendation_one: Are you sure that your proposal, or something very similar to it, has not yet been implemented? Take a few minutes to think about it and look for similar ideas on the web.
       recommendation_two: Are you sure that there is no similar proposal already on this platform? Browse proposals using keywords
       recommendation_three: Do not use capital letters for the proposal title or for whole sentences. On the internet, this is considered shouting. And nobody likes being shouted at.
       recommendation_four: Enjoy this space and the voices that fill it. It belongs to you too.
       recommendation_five: Any proposal or comment suggesting illegal action will be deleted, as well as those intending to sabotage the debate spaces. Anything else is allowed.
+      suggest_warning_html: "You are creating a complementary proposal of: <strong><a href=\"%{link}\">%{title}</a></strong>"
+      start_complementary: "Create a complementary proposal"
     show:
       proposal_objective: Proposal precise Objective/s
       proposal_feasible_explanation: Proposal feasilbility
       proposal_impact_description: Proposal impact
+      complementary_link: Create complementary proposal
+      act: Act
+      suggest_link: Suggest changes
+      suggest_text: Suggest changes to this proposal through the comments system.
+
   related_content:
     help: "You can add links of Proposals inside of %{org}."

--- a/config/locales/custom/es/general.yml
+++ b/config/locales/custom/es/general.yml
@@ -43,9 +43,16 @@ es:
       recommendation_three: No escribas el título de la propuesta o frases enteras en mayúsculas. En internet eso se considera gritar. Y a nadie le gusta que le griten.
       recommendation_four: Disfruta de este espacio, de las voces que lo llenan, también es tuyo.
       recommendation_five: Cualquier propuesta o comentario que implique una acción ilegal será eliminada, también las que tengan la intención de sabotear los espacios de propuesta, todo lo demás está permitido.
+      suggest_warning_html: "Estás creando una propuesta complementaria a: <strong><a href=\"%{link}\">%{title}</a></strong>"
+      start_complementary: "Crea una propuesta complementaria"
     show:
       proposal_objective: Objetivo/s concreto/s de la propuesta
       proposal_feasible_explanation: Aplicabilidad de la propuesta
       proposal_impact_description: Impacto de la propuesta
+      complementary_link: Crea propuesta complementaria
+      act: Actúa
+      suggest_link: Sugerir cambios
+      suggest_text: Sugiere cambios para esta propuesta a través del sistema de comentarios.
+
   related_content:
     help: "Puedes introducir cualquier enlace de Propuesta que esté dentro de %{org}."

--- a/spec/features/custom/proposals_spec.rb
+++ b/spec/features/custom/proposals_spec.rb
@@ -7,6 +7,11 @@ feature 'Masdemocraciaeuropa proposals' do
     Setting["feature.user.skip_verification"] = "true"
   end
 
+  before do
+    author = create(:user)
+    login_as(author)
+  end
+
   describe "New" do
     let!(:proposal) { create(:proposal) }
 
@@ -26,6 +31,18 @@ feature 'Masdemocraciaeuropa proposals' do
       visit new_proposal_path
 
       expect(page).not_to have_selector "textarea#question"
+    end
+
+    describe "Complementary proposal" do
+      scenario "Should display original proposal title" do
+        proposal = create(:proposal, title: "Original proposal", summary: "Summary", objective: "Objective <br> sample")
+        visit proposal_path(proposal)
+        click_on "Create complementary proposal"
+
+        expect(page).to have_content "Original proposal"
+        expect(page).to have_content "Create a complementary proposal"
+        expect(page).not_to have_content "Create new proposal"
+      end
     end
   end
 
@@ -141,6 +158,25 @@ feature 'Masdemocraciaeuropa proposals' do
       visit proposal_path(proposal)
 
       expect(page).to have_content "A very good feasible explanation"
+    end
+
+    describe "Suggest changes proposals" do
+      scenario "Should not display suggest changes text", :js do
+        proposal = create(:proposal, feasible_explanation: "A very good feasible explanation")
+
+        visit proposal_path(proposal)
+
+        expect(page).not_to have_content "Suggest changes to this proposal through the comments system."
+      end
+
+      scenario "Should display suggest changes text after click Suggest changes button", :js do
+        proposal = create(:proposal, feasible_explanation: "A very good feasible explanation")
+
+        visit proposal_path(proposal)
+        click_on "Suggest changes"
+
+        expect(page).to have_content "Suggest changes to this proposal through the comments system."
+      end
     end
 
   end


### PR DESCRIPTION
References
===================
* This PR solves a little piece of #74 

Objectives
===================
Get users attention to make them participate.

Add 2 buttons to proposal public page:

* Create a complementary proposal
* Suggest changes

**Complementaty button behavior**
This button will navigate to new proposals form with original_proposal_id as parameter. The at for title we will render "Create complementart proposal" and an alert box with original proposal information with link.

**Suggest changes button behavior*

This button should scroll to comments section with notice box with basic instructions.

Visual Changes
===================

**After**
![captura de pantalla 2018-07-09 a las 18 00 44](https://user-images.githubusercontent.com/15726/42461925-16d23b3a-83a2-11e8-90ff-bd06f8e3377b.png)
![captura de pantalla 2018-07-09 a las 18 00 07](https://user-images.githubusercontent.com/15726/42461926-16f5cae6-83a2-11e8-8861-1eec72ed491d.png)
![captura de pantalla 2018-07-09 a las 17 59 55](https://user-images.githubusercontent.com/15726/42461928-171431d4-83a2-11e8-96b9-70623c2ea58c.png)


Notes
===================
Proposal are not related via database!
