### PR TITLE
Add complementary proposals

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -384,7 +384,7 @@ body.auth-page{
 
   ul {
     padding-left: 20px;
-    
+
     li {
       padding-top: $line-height / 2;
       list-style-type: disc;
@@ -394,4 +394,9 @@ body.auth-page{
       }
     }
   }
+}
+
+.alternative-label{
+  background: #fcf8e3;
+  color: black;
 }

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -370,3 +370,28 @@ body.auth-page{
   font-size: 16px;
   border-bottom: solid 1px #dee0e3;
 }
+
+.alternative {
+
+  h2 {
+    font-size: rem-calc(24);
+
+    span {
+      color: #4f4f4f;
+      font-weight: normal;
+    }
+  }
+
+  ul {
+    padding-left: 20px;
+    
+    li {
+      padding-top: $line-height / 2;
+      list-style-type: disc;
+
+      &:not(:first-child) {
+        border-top: 1px solid $highlight;
+      }
+    }
+  }
+}

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -93,7 +93,7 @@ class ProposalsController < ApplicationController
     def proposal_params
       params.require(:proposal).permit(:title, :question, :summary, :description, :external_url, :video_url,
                                        :responsible_name, :tag_list, :terms_of_service, :geozone_id, :skip_map,
-                                       :objective, :feasible_explanation, :impact_description, :ancestry,
+                                       :objective, :feasible_explanation, :impact_description, :parent_id,
                                        image_attributes: [:id, :title, :attachment, :cached_attachment, :user_id, :_destroy],
                                        documents_attributes: [:id, :title, :attachment, :cached_attachment, :user_id, :_destroy],
                                        map_location_attributes: [:latitude, :longitude, :zoom])

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -26,7 +26,7 @@ class ProposalsController < ApplicationController
 
   def new
     super
-    @original_proposal = Proposal.find(params[:original_proposal_id]) if params[:original_proposal_id].present?
+    @proposal.parent = Proposal.find(params[:original_proposal_id]) if params[:original_proposal_id].present?
   end
 
   def show
@@ -93,7 +93,7 @@ class ProposalsController < ApplicationController
     def proposal_params
       params.require(:proposal).permit(:title, :question, :summary, :description, :external_url, :video_url,
                                        :responsible_name, :tag_list, :terms_of_service, :geozone_id, :skip_map,
-                                       :objective, :feasible_explanation, :impact_description,
+                                       :objective, :feasible_explanation, :impact_description, :ancestry,
                                        image_attributes: [:id, :title, :attachment, :cached_attachment, :user_id, :_destroy],
                                        documents_attributes: [:id, :title, :attachment, :cached_attachment, :user_id, :_destroy],
                                        map_location_attributes: [:latitude, :longitude, :zoom])

--- a/app/models/concerns/measurable.rb
+++ b/app/models/concerns/measurable.rb
@@ -4,7 +4,7 @@ module Measurable
   class_methods do
 
     def title_max_length
-      @@title_max_length ||= (columns.find { |c| c.name == 'title' }.limit rescue nil) || 80
+      @title_max_length ||= (columns.find { |c| c.name == 'title' }.limit rescue nil) || 80
     end
 
     def responsible_name_max_length

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -27,6 +27,7 @@ class Proposal < ActiveRecord::Base
 
   RETIRE_OPTIONS = %w(duplicated started unfeasible done other)
 
+  has_ancestry touch: true
   belongs_to :author, -> { with_hidden }, class_name: 'User', foreign_key: 'author_id'
   belongs_to :geozone
   has_many :comments, as: :commentable, dependent: :destroy

--- a/app/views/custom/proposals/_alternative.html.erb
+++ b/app/views/custom/proposals/_alternative.html.erb
@@ -1,0 +1,11 @@
+<div id="alternative" class="alternative">
+  <h2><%= t("proposals.show.alternative.title") %>&nbsp;<span>(<%= proposal.children.count %>)</span></h2>
+
+  <% if proposal.has_children? %>
+    <ul class="no-bullet document-link">
+      <% proposal.children.each do |alternative_proposal| %>
+        <li><%= link_to alternative_proposal.title, proposal_path(alternative_proposal), class: "proposal-link" %></li>
+      <% end %>
+    </ul>
+  <% end %>
+</div>

--- a/app/views/custom/proposals/_form.html.erb
+++ b/app/views/custom/proposals/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_for(@proposal, url: form_url) do |f| %>
   <%= render 'shared/errors', resource: @proposal %>
 
-  <%= f.hidden_field :ancestry %>
+  <%= f.hidden_field :parent_id %>
 
   <div class="row">
     <div class="small-12 column">

--- a/app/views/custom/proposals/_form.html.erb
+++ b/app/views/custom/proposals/_form.html.erb
@@ -1,6 +1,8 @@
 <%= form_for(@proposal, url: form_url) do |f| %>
   <%= render 'shared/errors', resource: @proposal %>
 
+  <%= f.hidden_field :ancestry %>
+
   <div class="row">
     <div class="small-12 column">
       <%= f.label :title, t("proposals.form.proposal_title") %>

--- a/app/views/custom/proposals/_proposal.html.erb
+++ b/app/views/custom/proposals/_proposal.html.erb
@@ -54,6 +54,15 @@
                 </span>
               <% end %>
             </p>
+
+            <% if setting['org_name'] == 'MASDEMOCRACIAEUROPA' && proposal.parent.present? %>
+              <p>
+                <span class="label round alternative-label">
+                  <%= t "proposals.index.alternative_html", title: proposal.parent.title, link: proposal_path(proposal.parent) %>
+                </span>
+              </p>
+            <% end %>
+
             <% if setting['org_name'] != "MASDEMOCRACIAEUROPA" %>
               <div class="proposal-description">
                 <p><%= proposal.summary %></p>

--- a/app/views/custom/proposals/new.html.erb
+++ b/app/views/custom/proposals/new.html.erb
@@ -13,9 +13,9 @@
         <%= t("proposals.new.more_info")%>
       <% end %>
     </div>
-    <% if @original_proposal.present? %>
+    <% if @proposal.parent.present? %>
       <div data-alert class="callout warning">
-        <%= t "proposals.new.suggest_warning_html", title: @original_proposal.title, link: proposal_path(@original_proposal) %>
+        <%= t "proposals.new.suggest_warning_html", title: @proposal.parent.title, link: proposal_path(@proposal.parent) %>
       </div>
     <% end %>
     <%= render "proposals/form", form_url: proposals_url %>

--- a/app/views/custom/proposals/new.html.erb
+++ b/app/views/custom/proposals/new.html.erb
@@ -3,7 +3,7 @@
   <div class="small-12 medium-9 column">
     <%= back_link_to %>
 
-    <% if @original_proposal.present? %>
+    <% if @proposal.parent.present? %>
       <h1><%= t("proposals.new.start_complementary") %></h1>
     <% else %>
       <h1><%= t("proposals.new.start_new") %></h1>

--- a/app/views/custom/proposals/show.html.erb
+++ b/app/views/custom/proposals/show.html.erb
@@ -54,6 +54,12 @@
 
         </div>
 
+        <% if @proposal.parent.present? %>
+          <div id="alternative-alert" data-alert class="callout warning">
+            <%= t "proposals.show.suggest_warning_html", title: @proposal.parent.title, link: proposal_path(@proposal.parent) %>
+          </div>
+        <% end %>
+
         <%= render_image(@proposal.image, :large, true) if @proposal.image.present? %>
 
         <br>
@@ -128,13 +134,15 @@
           </div>
         <% end %>
 
+        <%= render 'shared/tags', taggable: @proposal %>
+
         <% if feature?(:allow_attached_documents) %>
           <%= render 'documents/documents',
                       documents: @proposal.documents,
                       max_documents_allowed: Proposal.max_documents_allowed %>
         <% end %>
 
-        <%= render 'shared/tags', taggable: @proposal %>
+        <%= render 'proposals/alternative', proposal: @proposal %>
 
         <%= render 'shared/geozone', geozonable: @proposal if setting['org_name'] != 'MASDEMOCRACIAEUROPA' %>
 

--- a/app/views/proposals/_proposal.html.erb
+++ b/app/views/proposals/_proposal.html.erb
@@ -54,6 +54,7 @@
                 </span>
               <% end %>
             </p>
+
             <div class="proposal-description">
               <p><%= proposal.summary %></p>
               <div class="truncate"></div>

--- a/config/locales/custom/en/general.yml
+++ b/config/locales/custom/en/general.yml
@@ -22,6 +22,8 @@ en:
   social:
     linkedin: "%{org} LinkedIn"
   proposals:
+    index:
+      alternative_html: "<strong>Complementary proposal of: <br class=\"show-for-small-only\" /><a href=\"%{link}\">%{title}</a></strong>"
     form:
       proposal_feasible_explanation: Is your proposal actionable?
       proposal_feasible_explanation_note_html: Explain briefly what does it take to have your proposal implemented, including if possible an even rough estimation of the cost of it. <br>(max 1700 characters ~ 300 words)
@@ -52,6 +54,9 @@ en:
       suggest_warning_html: "You are creating a complementary proposal of: <strong><a href=\"%{link}\">%{title}</a></strong>"
       start_complementary: "Create a complementary proposal"
     edit:
+      form:
+        submit_button_custom: Save changes
+    update:
       form:
         submit_button_custom: Save changes
     show:

--- a/config/locales/custom/en/general.yml
+++ b/config/locales/custom/en/general.yml
@@ -62,6 +62,9 @@ en:
       act: Act
       suggest_link: Suggest changes
       suggest_text: Suggest changes to this proposal through the comments system.
+      suggest_warning_html: "You are viewing a complementary proposal of: <strong><a href=\"%{link}\">%{title}</a></strong>"
+      alternative:
+        title: Complementary proposals
     retire_form:
       warning: "If you retire the proposal it will be removed from the main list and a message will be visible to all users stating that the author considers the proposal should not be detectable"
       retired_explanation_placeholder: Explain shortly why you think this proposal should not be detectable

--- a/config/locales/custom/es/general.yml
+++ b/config/locales/custom/es/general.yml
@@ -63,6 +63,9 @@ es:
       act: Actúa
       suggest_link: Sugiere cambios a esta propuesta
       suggest_text: Sugiere cambios para esta propuesta a través del sistema de comentarios.
+      suggest_warning_html: "Estás viendo una propuesta alternativa a: <strong><a href=\"%{link}\">%{title}</a></strong>"
+      alternative:
+        title: Propuestas alternativas
     retire_form:
       warning: "Si sigues adelante tu propuesta dejará de ser listada en la lista principal, y aparecerá un mensaje para todos los usuarios avisándoles de que el autor considera que esta propuesta no debe seguir visible."
       retired_explanation_placeholder: Explica brevemente por que consideras que esta propuesta no debe ser visible

--- a/config/locales/custom/es/general.yml
+++ b/config/locales/custom/es/general.yml
@@ -22,6 +22,8 @@ es:
   social:
     linkedin: "LinkedIn de %{org}"
   proposals:
+    index:
+      alternative_html: "<strong>Propuesta alternativa a: <br class=\"show-for-small-only\" /><a href=\"%{link}\">%{title}</a></strong>"
     form:
       proposal_feasible_explanation: ¿Es factible tu propuesta?
       proposal_feasible_explanation_note_html: Explica brevemente cómo puede llevarse la propuesta a la práctica, incluyendo si es posible una estimación, aún en términos generales, de su coste. <br>(max 1700 caracteres ~ 300 palabras)
@@ -53,6 +55,9 @@ es:
       suggest_warning_html: "Estás creando una propuesta alternativa a: <strong><a href=\"%{link}\">%{title}</a></strong>"
       start_complementary: "Crea una propuesta alternativa"
     edit:
+      form:
+        submit_button_custom: Guardar cambios
+    update:
       form:
         submit_button_custom: Guardar cambios
     show:

--- a/db/migrate/20180719093029_add_ancestry_to_proposals.rb
+++ b/db/migrate/20180719093029_add_ancestry_to_proposals.rb
@@ -1,0 +1,6 @@
+class AddAncestryToProposals < ActiveRecord::Migration
+  def change
+    add_column :proposals, :ancestry, :string
+    add_index :proposals, :ancestry
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180704132918) do
+ActiveRecord::Schema.define(version: 20180719093029) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -876,21 +876,21 @@ ActiveRecord::Schema.define(version: 20180704132918) do
   end
 
   create_table "proposals", force: :cascade do |t|
-    t.string   "title",                limit: 80
+    t.string   "title",                limit: 120
     t.text     "description"
     t.string   "question"
     t.string   "external_url"
     t.integer  "author_id"
     t.datetime "hidden_at"
-    t.integer  "flags_count",                     default: 0
+    t.integer  "flags_count",                      default: 0
     t.datetime "ignored_flag_at"
-    t.integer  "cached_votes_up",                 default: 0
-    t.integer  "comments_count",                  default: 0
+    t.integer  "cached_votes_up",                  default: 0
+    t.integer  "comments_count",                   default: 0
     t.datetime "confirmed_hide_at"
-    t.integer  "hot_score",            limit: 8,  default: 0
-    t.integer  "confidence_score",                default: 0
-    t.datetime "created_at",                                  null: false
-    t.datetime "updated_at",                                  null: false
+    t.integer  "hot_score",            limit: 8,   default: 0
+    t.integer  "confidence_score",                 default: 0
+    t.datetime "created_at",                                   null: false
+    t.datetime "updated_at",                                   null: false
     t.string   "responsible_name",     limit: 60
     t.text     "summary"
     t.string   "video_url"
@@ -903,8 +903,10 @@ ActiveRecord::Schema.define(version: 20180704132918) do
     t.text     "objective"
     t.text     "feasible_explanation"
     t.text     "impact_description"
+    t.string   "ancestry"
   end
 
+  add_index "proposals", ["ancestry"], name: "index_proposals_on_ancestry", using: :btree
   add_index "proposals", ["author_id", "hidden_at"], name: "index_proposals_on_author_id_and_hidden_at", using: :btree
   add_index "proposals", ["author_id"], name: "index_proposals_on_author_id", using: :btree
   add_index "proposals", ["cached_votes_up"], name: "index_proposals_on_cached_votes_up", using: :btree

--- a/spec/features/custom/proposals_spec.rb
+++ b/spec/features/custom/proposals_spec.rb
@@ -121,6 +121,19 @@ feature 'Masdemocraciaeuropa proposals' do
       expect(page).not_to have_selector "#advanced_search_official_level"
     end
 
+    scenario "Should display original proposal link inside complementary proposals", :js do
+      proposal = create(:proposal)
+      complementary_proposal = create(:proposal, parent: proposal)
+      visit proposals_path
+
+      within "#proposal_#{proposal.id}" do
+        expect(page).not_to have_link complementary_proposal.title
+      end
+      within "#proposal_#{complementary_proposal.id}" do
+        expect(page).to have_link proposal.title
+      end
+    end
+
   end
 
   describe "Show" do

--- a/spec/features/custom/proposals_spec.rb
+++ b/spec/features/custom/proposals_spec.rb
@@ -193,6 +193,40 @@ feature 'Masdemocraciaeuropa proposals' do
       end
     end
 
+    scenario "Should display complementary proposals at parent proposal" do
+      proposal = create(:proposal, title: "Original proposal title")
+      complementary_proposal = create(:proposal, title: "Complementary proposal title", parent: proposal)
+      visit proposal_path(proposal)
+
+      within "#alternative" do
+        expect(page).to have_link complementary_proposal.title
+      end
+    end
+
+    scenario "Should display original proposals at complementary (children) proposals" do
+      proposal = create(:proposal, title: "Original proposal title")
+      complementary_proposal = create(:proposal, title: "Complementary proposal title", parent: proposal)
+      visit proposal_path(complementary_proposal)
+
+      within "#alternative-alert" do
+        expect(page).to have_link 'Original proposal title'
+      end
+    end
+
+    scenario "Should allow to create complementary proposal from any proposal" do
+      proposal = create(:proposal, title: "Original proposal title")
+      visit proposal_path(proposal)
+
+      click_on "Create complementary proposal"
+      fill_proposal_form
+      check 'proposal_terms_of_service'
+      click_button 'Send your proposal'
+      expect(page).to have_content 'Proposal created successfully.'
+      click_on 'Not now, go to my proposal'
+
+      expect(page).to have_content "You are viewing a complementary proposal of: #{proposal.title}"
+    end
+
   end
 
   describe "Create" do
@@ -201,14 +235,7 @@ feature 'Masdemocraciaeuropa proposals' do
       login_as(author)
       visit new_proposal_path
 
-      fill_in 'proposal_title', with: 'Help refugees'
-      fill_in 'proposal_objective', with: 'To minimize refugees at Europe'
-      fill_in 'proposal_impact_description', with: 'This should affect to ..'
-      fill_in 'proposal_feasible_explanation', with: 'This could be done if all of we ...'
-      fill_in 'proposal_description', with: 'This is very important because...'
-      fill_in 'proposal_external_url', with: 'http://rescue.org/refugees'
-      fill_in 'proposal_video_url', with: 'https://www.youtube.com/watch?v=yPQfcG-eimk'
-      fill_in 'proposal_tag_list', with: 'Refugees, Solidarity'
+      fill_proposal_form
       check 'proposal_terms_of_service'
 
       click_button 'Send your proposal'
@@ -240,4 +267,15 @@ feature 'Masdemocraciaeuropa proposals' do
       expect(page).to have_content "Proposal updated successfully."
     end
   end
+end
+
+def fill_proposal_form
+  fill_in 'proposal_title', with: 'Help refugees'
+  fill_in 'proposal_objective', with: 'To minimize refugees at Europe'
+  fill_in 'proposal_impact_description', with: 'This should affect to ..'
+  fill_in 'proposal_feasible_explanation', with: 'This could be done if all of we ...'
+  fill_in 'proposal_description', with: 'This is very important because...'
+  fill_in 'proposal_external_url', with: 'http://rescue.org/refugees'
+  fill_in 'proposal_video_url', with: 'https://www.youtube.com/watch?v=yPQfcG-eimk'
+  fill_in 'proposal_tag_list', with: 'Refugees, Solidarity'
 end

--- a/spec/models/custom/proposal_spec.rb
+++ b/spec/models/custom/proposal_spec.rb
@@ -17,6 +17,10 @@ describe Proposal do
     expect(proposal).to be_valid
   end
 
+  it "is valid without ancestry" do
+    expect(proposal).to be_valid
+  end
+
   context "when Setting['org_name'] is 'MASDEMOCRACIAEUROPA'" do
 
     before { Setting['org_name'] = 'MASDEMOCRACIAEUROPA' }

--- a/spec/models/custom/proposal_spec.rb
+++ b/spec/models/custom/proposal_spec.rb
@@ -74,7 +74,7 @@ describe Proposal do
     end
 
     it "is not valid when title is longer than 120 characters" do
-      proposal.title = "a" * 120
+      proposal.title = "a" * 121
 
       expect(proposal).not_to be_valid
     end

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -36,7 +36,7 @@ describe Proposal do
     end
 
     it "is not valid when very long" do
-      proposal.title = "a" * 81
+      proposal.title = "a" * 121
       expect(proposal).not_to be_valid
     end
   end


### PR DESCRIPTION
References
===================
* Issues: 

Objectives
===================
Persist proposals relations.
One proposal can has many alternative proposals, and one proposals can belong to a 

How
===================
Using ancestry gem at proposal model.

Visual Changes
===================

**After**
Proposals#show page showing alternative proposals.
![captura de pantalla 2018-07-19 a las 13 32 45](https://user-images.githubusercontent.com/15726/42940045-56c8f432-8b58-11e8-9dd5-22399d2a58c9.png)

Proposals#show page showing alternative proposal original proposal link .
![captura de pantalla 2018-07-19 a las 13 33 52](https://user-images.githubusercontent.com/15726/42940063-6984277c-8b58-11e8-9577-3458814043ac.png)

Proposals#index && Managments/Proposals#index showing parent proposal only to administrators, managers, moderators
![captura de pantalla 2018-07-19 a las 14 23 24](https://user-images.githubusercontent.com/15726/42942204-76481796-8b5f-11e8-8c05-5a5e412e692f.png)
![captura de pantalla 2018-07-19 a las 14 23 08](https://user-images.githubusercontent.com/15726/42942205-7666ed88-8b5f-11e8-9539-4eb5ca362a20.png)



Specs
===================
Increased to cover new cases.

