### PR TITLE
Override default application twitter image for social networks

### DIFF
--- a/app/views/custom/shared/_social_media_meta_tags.html.erb
+++ b/app/views/custom/shared/_social_media_meta_tags.html.erb
@@ -5,7 +5,7 @@
 <meta name="twitter:site" content="<%= setting['twitter_handle'] %>"/>
 <meta name="twitter:title" content="<%= local_assigns[:social_title] || setting['meta_title'] %>"/>
 <meta name="twitter:description" content="<%= description %>"/>
-<meta name="twitter:image" content="<%= root_url + (local_assigns[:twitter_image_url] || 'social_media_icon_twitter.png') %>"/>
+<meta name="twitter:image" content="<%= root_url + (local_assigns[:twitter_image_url] || 'logo_mas_democracia_eu.png') %>"/>
 <!-- Facebook OG -->
 <meta id="ogtitle" property="og:title" content="<%= local_assigns[:social_title] || setting['meta_title'] %>"/>
 <% if setting['url'] %>


### PR DESCRIPTION
References
===================
#86 

Objectives
===================
Fix Twitter default image to share.

Visual Changes
===================
![captura de pantalla 2018-07-20 a las 18 18 16](https://user-images.githubusercontent.com/15726/43013470-498ef72a-8c49-11e8-9264-64873c57b12d.png)


